### PR TITLE
Use network bools instead of nw messages

### DIFF
--- a/lua/autorun/client/cfc_attention_monitoring_cl_init.lua
+++ b/lua/autorun/client/cfc_attention_monitoring_cl_init.lua
@@ -1,4 +1,3 @@
-local IsValid = IsValid
 local ipairs = ipairs
 local player_GetAll = player.GetAll
 
@@ -38,7 +37,7 @@ hook.Add( "PostPlayerDraw", "CFC_AttentionMonitor_AfkRenderElements", function()
     local me = LocalPlayer()
 
     for _, ply in ipairs( player_GetAll() ) do
-        if ply ~= me and IsValid( ply ) then
+        if ply ~= me then
             if ply:GetNW2Bool( "IsTabbedOut" ) then
                 pcall( renderTabbedOut, ply )
             end

--- a/lua/autorun/client/cfc_attention_monitoring_cl_init.lua
+++ b/lua/autorun/client/cfc_attention_monitoring_cl_init.lua
@@ -1,41 +1,47 @@
-local tabbedOutList = {}
+local IsValid = IsValid
+local ipairs = ipairs
+local player_GetAll = player.GetAll
+
 local isTabbedOut = false
 local icon = Material( "icon16/monitor.png", "3D" )
 
-local function renderables( ply )
-    if not IsValid( ply ) then return end
-    if ply == LocalPlayer() then return end
+local spriteColor = Color( 225, 225, 225, 225 )
+local spriteBoneOffset = Vector( 0, 0, 12 )
+local spriteOffset = Vector( 0, 0, 73 )
 
-        local attachment = ply:GetAttachment( ply:LookupAttachment("eyes") ) -- gets the eye bone of the player
+local function renderTabbedOut( ply )
+    local eyes = ply:LookupAttachment( "eyes" )
+    local attachment = ply:GetAttachment( eyes )
 
-        if attachment then -- checks if it got the bone
-            pos = ply:GetAttachment( ply:LookupAttachment( "eyes" ) ).Pos + Vector( 0, 0, 12 )
-        else
-            pos = ply:GetPos() + Vector( 0, 0, 73 )
-        end
+    if attachment then -- checks if it got the bone
+        pos = attachment.Pos + spriteBoneOffset
+    else
+        pos = ply:GetPos() + spriteOffset
+    end
 
-        render.SetMaterial( icon )
-        render.DrawSprite( pos, 16, 16, Color( 225, 225, 225, 255 ) )
-
+    render.SetMaterial( icon )
+    render.DrawSprite( pos, 16, 16, spriteColor )
 end
 
 timer.Create( "CFC_AttentionMonitor_TabNetTimmer", 0.5, 0, function()
     local hasFocus = system.HasFocus()
-
     if isTabbedOut == hasFocus then return end
 
     net.Start( "CFC_AttentionMonitor_GameHasFocus" )
         net.WriteBool( hasFocus )
     net.SendToServer()
+
     isTabbedOut = hasFocus
 end )
 
-net.Receive( "CFC_AttentionMonitor_SendData", function() -- receives the players that tabbed out
-    tabbedOutList = net.ReadTable()
-end )
-
 hook.Add( "PostPlayerDraw", "CFC_AttentionMonitor_AfkRenderElements", function()
-    for ply in pairs( tabbedOutList ) do -- draws the icon for each tabbed out player
-        renderables( ply )
+    local me = LocalPlayer()
+
+    for _, ply in ipairs( player_GetAll() ) do
+        if ply ~= me and IsValid( ply ) then
+            if ply:GetNW2Bool( "IsTabbedOut" ) then
+                pcall( renderTabbedOut, ply )
+            end
+        end
     end
 end )


### PR DESCRIPTION
So we can access this info in other addons, I tweaked the addon to use Network Bools instead of sending updates with network messages.
Marginally less performant, perhaps, but it'll allow us to use this in the scoreboard, for example.

I also refactored a few pain points I noticed while I was in there.
