### PR TITLE
Reduce ent.__index calls and track netvars

### DIFF
--- a/lua/autorun/client/cfc_attention_monitoring_cl_init.lua
+++ b/lua/autorun/client/cfc_attention_monitoring_cl_init.lua
@@ -34,15 +34,6 @@ local RENDERMODE_TRANSALPHA = RENDERMODE_TRANSALPHA
 
 local trackedPlayers = {}
 
-local function removeTrackedPlayer( ply )
-    for i, trackedPly in ipairs( trackedPlayers ) do
-        if trackedPly == ply then
-            table.remove( trackedPlayers, i )
-            break
-        end
-    end
-end
-
 surface.CreateFont( timeFont, {
         font = "Arial",
         size = 65,
@@ -70,7 +61,10 @@ local function formatAfkTime( rawTime )
 end
 
 local function drawIcon( ply )
-    if not IsValid( ply ) then removeTrackedPlayer( ply ) return end
+    if not IsValid( ply ) then
+        table.RemoveByValue( trackedPlayers, ply )
+        return
+    end
     if not isAlive( ply ) then return end
     if isDormant( ply ) then return end
     if getRenderMode( ply ) == RENDERMODE_TRANSALPHA then return end
@@ -129,7 +123,7 @@ hook.Add( "EntityNetworkedVarChanged", "CFC_AttentionMonitor", function( ent, na
     if newval then
         table.insert( trackedPlayers, ent )
     else
-        removeTrackedPlayer( ent )
+        table.RemoveByValue( trackedPlayers, ent )
     end
 end )
 

--- a/lua/autorun/client/cfc_attention_monitoring_cl_init.lua
+++ b/lua/autorun/client/cfc_attention_monitoring_cl_init.lua
@@ -34,6 +34,15 @@ local RENDERMODE_TRANSALPHA = RENDERMODE_TRANSALPHA
 
 local trackedPlayers = {}
 
+local function removeTrackedPlayer( ply )
+    for i, trackedPly in ipairs( trackedPlayers ) do
+        if trackedPly == ply then
+            table.remove( trackedPlayers, i )
+            break
+        end
+    end
+end
+
 surface.CreateFont( timeFont, {
         font = "Arial",
         size = 65,
@@ -61,6 +70,7 @@ local function formatAfkTime( rawTime )
 end
 
 local function drawIcon( ply )
+    if not IsValid( ply ) then removeTrackedPlayer( ply ) return end
     if not isAlive( ply ) then return end
     if isDormant( ply ) then return end
     if getRenderMode( ply ) == RENDERMODE_TRANSALPHA then return end
@@ -119,12 +129,7 @@ hook.Add( "EntityNetworkedVarChanged", "CFC_AttentionMonitor", function( ent, na
     if newval then
         table.insert( trackedPlayers, ent )
     else
-        for i, ply in ipairs( trackedPlayers ) do
-            if ply == ent then
-                table.remove( trackedPlayers, i )
-                break
-            end
-        end
+        removeTrackedPlayer( ent )
     end
 end )
 

--- a/lua/autorun/client/cfc_attention_monitoring_cl_init.lua
+++ b/lua/autorun/client/cfc_attention_monitoring_cl_init.lua
@@ -51,11 +51,19 @@ local function formatAfkTime( rawTime )
     return timeStr
 end
 
+local plyMeta = FindMetaTable( "Player" )
+local isAlive = plyMeta.Alive
+
+local entMeta = FindMetaTable( "Entity" )
+local isDormant = entMeta.IsDormant
+local getRenderMode = entMeta.GetRenderMode
+local getNW2Bool = entMeta.GetNW2Bool
+
 local function drawIcon( ply )
-    if not ply:Alive() then return end
-    if ply:IsDormant() then return end
-    if ply:GetRenderMode() == RENDERMODE_TRANSALPHA then return end
-    if not ply:GetNW2Bool( "CFC_AM_IsTabbedOut" ) then return end
+    if not isAlive( ply ) then return end
+    if isDormant( ply ) then return end
+    if getRenderMode( ply ) == RENDERMODE_TRANSALPHA then return end
+    if not getNW2Bool( ply, "CFC_AM_IsTabbedOut" ) then return end
     if ply == LocalPlayer() then return end
 
     -- Position


### PR DESCRIPTION
After seeing this constantly hit the top of fprofiler i figured it'd be good to fix.

- Only renders players that are tracked instead of looping over all players.
- Reduced index calls

This was tested and works.