### PR TITLE
Fix LocalPlayer being NULL error

### DIFF
--- a/lua/autorun/client/cfc_attention_monitoring_cl_init.lua
+++ b/lua/autorun/client/cfc_attention_monitoring_cl_init.lua
@@ -129,7 +129,7 @@ end )
 
 gameevent.Listen( "OnRequestFullUpdate" )
 hook.Add( "OnRequestFullUpdate", "CFC_AttentionMonitor", function( data )
-    if data.userid ~= LocalPlayer():UserID() then return end
+    if Player( data.userid ) ~= LocalPlayer() then return end
 
     trackedPlayers = {}
 end )


### PR DESCRIPTION
`OnRequestFullUpdate` runs before entities are valid
Fixes:
1.  func - addons/cfc_attention_monitoring/lua/autorun/client/cfc_attention_monitoring_cl_init.lua:132
 2.  unknown - addons/ulib/lua/includes/modules/hook.lua:260
